### PR TITLE
updated ios page transition to smooth out small glitch on leave

### DIFF
--- a/stylesheets/_transitions.scss
+++ b/stylesheets/_transitions.scss
@@ -87,7 +87,7 @@ $ios-transition-box-shadow:            0px 0px 12px rgba(0,0,0,0.5);
     }
     .nav-view-leaving.nav-view-active {
       opacity: 0.9;
-      @include translate3d(98%, 0, 0);
+      @include translate3d(101%, 0, 0);
     }
   }
 


### PR DESCRIPTION
I have implemented a small fix to the leave state of the page transition in ios. There is a small glitch at the end of the transition where the animation stops a few pixels and then continues to leave the stage. The glitch is hidden by pushing the page beyond the stage by changing transition end position to 101%
